### PR TITLE
fix: update default language logic to prioritize user preference

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -27,6 +27,27 @@ export const getCurrentLocale = (): SupportedLocale => {
   if (saved && supportedLocales.some(l => l.code === saved)) {
     return saved
   }
+
+  const navigatorLanguages = navigator.languages || [navigator.language]
+
+  for (const lang of navigatorLanguages) {
+    const lower = lang.toLowerCase()
+
+    // Special handling for zh
+    if (lower.startsWith('zh')) {
+      if (['zh', 'zh-cn', 'zh-sg', 'zh-my', 'zh-hans'].includes(lower)) {
+        return 'zh-CN'
+      }
+      return 'zh-TW'
+    }
+
+    // Prefix matching for other languages
+    if (lower.startsWith('en')) return 'en'
+    if (lower.startsWith('ja')) return 'ja'
+    if (lower.startsWith('fr')) return 'fr'
+    if (lower.startsWith('es')) return 'es'
+  }
+
   return 'zh-TW'
 }
 


### PR DESCRIPTION
This PR updates the `getCurrentLocale` function to better respect the user's browser language preferences.

**Changes:**
- Now iterates through `navigator.languages` to find the first supported language instead of relying on a single default.
- Adds specific handling for `zh` variants.
- Supports prefix matching for English, Japanese, French, and Spanish.
- Falls back to `zh-TW` only if no supported language is found in the user's preferences.

**Why:**
Previously, the application could default to `zh-TW` even if the user had English or another supported language set as their preference. This change ensures a better initial experience for international users by prioritizing their browser settings.
