### PR TITLE
修正簡體中文 i18n

### DIFF
--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -28,7 +28,7 @@ export default {
 
   // 首页
   home: {
-    title: '🚀 应用Sensemaker做分析',
+    title: '🚀 意见综整器',
     apiKeyLabel: '🔑 OpenRouter API Key',
     apiKeyPlaceholder: '请输入您的 OpenRouter API Key',
     getApiKeyLink: '申请 API Key',


### PR DESCRIPTION
目前簡體中文的標題使用 "应用Sensemaker做分析"，看起來有點怪怪的，不確定是不是 AI 翻譯的問題。這個 PR 改成使用 "意见综整器"

再麻煩 @bestian 確認

![1764036754100](https://github.com/user-attachments/assets/0911675b-ce93-4a00-8576-ca84f1d88440)
