### PR TITLE
多語系標題取消英文輔助

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -158,23 +158,23 @@ export default {
 
   // Privacy page
   privacy: {
-    title: 'Privacy Policy / Privacy Policy',
+    title: 'Privacy Policy',
     privacyPolicy: 'Privacy Policy',
     privacyDescription: 'This application does not collect any private data whatsoever. Generated reports are temporarily stored in R2 storage service for your download and cannot be accessed by other users.',
     privacyPolicyEn: 'Privacy Policy',
     privacyDescriptionEn: 'This application does not collect any private data whatsoever. Generated reports are temporarily stored in R2 storage service for your download and cannot be accessed by other users.',
-    dataProcessingTitle: 'About Data Processing / About Data Processing',
+    dataProcessingTitle: 'About Data Processing',
     backendProcessing: 'Backend Processing: Data is sent to our backend for computation, but no user data is stored on our servers, especially API keys are never stored.',
     noCookies: 'No Cookies: We do not use any cookies.',
     openSource: 'Open Source Transparency: Our code is completely open source, and you can review all functionality to ensure privacy.',
-    frontendProject: 'Frontend Project (Frontend)',
-    backendProject: 'Backend Project (Backend)',
+    frontendProject: 'Frontend Project',
+    backendProject: 'Backend Project',
     openSourceNote: 'Open Source Transparency: Our code is completely open source, and you can review all functionality to ensure privacy. Check our frontend and backend repositories on GitHub.'
   },
 
   // Self-host page
   selfHost: {
-    title: '🏗️ Self-Hosting Guide / Self-Hosting Guide',
+    title: '🏗️ Self-Hosting Guide',
     overviewTitle: '📋 Overview',
     overviewDescription: 'If you have concerns about privacy and data security, you\'re welcome to fork our project and self-host the service. This way you have complete control over your data and API keys.',
     paidPlanTitle: 'Paid Plan Requirements',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -150,21 +150,21 @@ export default {
 
   // Página de Privacidad
   privacy: {
-    title: 'Política de privacidad / Privacy Policy',
+    title: 'Política de privacidad',
     privacyPolicy: 'Política de privacidad',
     privacyDescription: 'Esta aplicación no recolecta ningún dato personal. Los reportes generados se almacenan temporalmente en el servicio de almacenamiento R2 para su descarga y no pueden ser accedidos por otros usuarios.',
-    dataProcessingTitle: 'Acerca del procesamiento de datos / About Data Processing',
+    dataProcessingTitle: 'Acerca del procesamiento de datos',
     backendProcessing: 'Procesamiento backend: Los datos se envían a nuestro backend para cálculo, pero ningún dato de usuario se almacena en nuestros servidores, especialmente las claves API nunca se almacenan.',
     noCookies: 'Sin cookies: No usamos ninguna cookie.',
     openSource: 'Transparencia de código abierto: Nuestro código es completamente de código abierto, y puede revisar toda la funcionalidad para asegurar la privacidad.',
-    frontendProject: 'Proyecto frontend (Frontend)',
-    backendProject: 'Proyecto backend (Backend)',
+    frontendProject: 'Proyecto frontend',
+    backendProject: 'Proyecto backend',
     openSourceNote: 'Transparencia de código abierto: Nuestro código es completamente de código abierto, y puede revisar toda la funcionalidad para asegurar la privacidad. Revise nuestros repositorios frontend y backend en GitHub.'
   },
 
   // Página de Auto-alojamiento
   selfHost: {
-    title: '🏗️ Guía de auto-alojamiento / Self-Hosting Guide',
+    title: '🏗️ Guía de auto-alojamiento',
     overviewTitle: '📋 Resumen',
     overviewDescription: 'Si tiene inquietudes sobre privacidad y seguridad de datos, le invitamos a hacer fork de nuestro proyecto y auto-alojar el servicio. De esta manera tiene control completo sobre sus datos y claves API.',
     paidPlanTitle: 'Requisitos de plan pagado',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -150,21 +150,21 @@ export default {
 
   // Page Confidentialité
   privacy: {
-    title: 'Politique de confidentialité / Privacy Policy',
+    title: 'Politique de confidentialité',
     privacyPolicy: 'Politique de confidentialité',
     privacyDescription: 'Cette application ne collecte aucune donnée personnelle. Les rapports générés sont temporairement stockés dans le service de stockage R2 pour votre téléchargement et ne peuvent pas être consultés par d\'autres utilisateurs.',
-    dataProcessingTitle: 'À propos du traitement des données / About Data Processing',
+    dataProcessingTitle: 'À propos du traitement des données',
     backendProcessing: 'Traitement backend : Les données sont envoyées à notre backend pour calcul, mais aucune donnée utilisateur n\'est stockée sur nos serveurs, surtout les clés API ne sont jamais stockées.',
     noCookies: 'Pas de cookies : Nous n\'utilisons aucun cookie.',
     openSource: 'Transparence open source : Notre code est complètement open source, et vous pouvez examiner toutes les fonctionnalités pour assurer la confidentialité.',
-    frontendProject: 'Projet frontend (Frontend)',
-    backendProject: 'Projet backend (Backend)',
+    frontendProject: 'Projet frontend',
+    backendProject: 'Projet backend',
     openSourceNote: 'Transparence open source : Notre code est complètement open source, et vous pouvez examiner toutes les fonctionnalités pour assurer la confidentialité. Consultez nos dépôts frontend et backend sur GitHub.'
   },
 
   // Page Auto-hébergement
   selfHost: {
-    title: '🏗️ Guide d\'auto-hébergement / Self-Hosting Guide',
+    title: '🏗️ Guide d\'auto-hébergement',
     overviewTitle: '📋 Aperçu',
     overviewDescription: 'Si vous avez des préoccupations concernant la confidentialité et la sécurité des données, vous êtes invités à forker notre projet et auto-héberger le service. De cette façon, vous avez un contrôle complet sur vos données et clés API.',
     paidPlanTitle: 'Exigences de plan payant',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -150,21 +150,21 @@ export default {
 
   // プライバシーページ
   privacy: {
-    title: 'プライバシーポリシー / Privacy Policy',
+    title: 'プライバシーポリシー',
     privacyPolicy: 'プライバシーポリシー',
     privacyDescription: 'このアプリケーションは個人データを一切収集しません。生成されたレポートは一時的にR2ストレージサービスに保存され、あなたがダウンロードできるようになっており、他のユーザーがアクセスすることはできません。',
-    dataProcessingTitle: 'データ処理について / About Data Processing',
+    dataProcessingTitle: 'データ処理について',
     backendProcessing: 'バックエンド処理：データはバックエンドに送信されて計算されますが、ユーザーデータはサーバーに保存されません。特にAPIキーは決して保存されません。',
     noCookies: 'Cookieなし：Cookieは使用しません。',
     openSource: 'オープンソースによる透明性：私たちのコードは完全にオープンソースで、プライバシーを確保するためにすべての機能を確認できます。',
-    frontendProject: 'フロントエンドプロジェクト (Frontend)',
-    backendProject: 'バックエンドプロジェクト (Backend)',
+    frontendProject: 'フロントエンドプロジェクト',
+    backendProject: 'バックエンドプロジェクト',
     openSourceNote: 'オープンソースによる透明性：私たちのコードは完全にオープンソースで、プライバシーを確保するためにすべての機能を確認できます。GitHubでフロントエンドとバックエンドのリポジトリを確認してください。'
   },
 
   // セルフホストページ
   selfHost: {
-    title: '🏗️ セルフホストガイド / Self-Hosting Guide',
+    title: '🏗️ セルフホストガイド',
     overviewTitle: '📋 概要',
     overviewDescription: 'プライバシーとデータセキュリティに懸念がある場合は、私たちのプロジェクトをフォークしてサービスをセルフホストすることを歓迎します。これにより、データとAPIキーを完全に制御できます。',
     paidPlanTitle: '有料プラン要件',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -150,21 +150,21 @@ export default {
 
   // 隐私权页面
   privacy: {
-    title: '隐私权政策 / Privacy Policy',
+    title: '隐私权政策',
     privacyPolicy: '隐私权政策',
     privacyDescription: '这款应用程序不会搜集任何个人资料。生成的报告会暂时存储于 R2 存储服务中供您下载，并以唯一的 taskID 识别，其他使用者无法取得或存取您的资料。',
-    dataProcessingTitle: '关于资料处理 / About Data Processing',
+    dataProcessingTitle: '关于资料处理',
     backendProcessing: '后端运算：资料会传送到后端进行运算处理，但后端不会储存任何使用者的个人资料和敏感信息，特别是API KEY不会被储存。',
     noCookies: '无cookies：我们不使用任何 cookies。',
     openSource: '开源透明：我们的代码完全开源，您可以检视所有功能以确保隐私安全。',
-    frontendProject: '前端项目 (Frontend)',
-    backendProject: '后端项目 (Backend)',
+    frontendProject: '前端项目',
+    backendProject: '后端项目',
     openSourceNote: 'Open Source Transparency: Our code is completely open source, and you can review all functionality to ensure privacy. Check our frontend and backend repositories on GitHub.'
   },
 
   // 自行架站页面
   selfHost: {
-    title: '🏗️ 自行架站指南 / Self-Hosting Guide',
+    title: '🏗️ 自行架站指南',
     overviewTitle: '📋 概述',
     overviewDescription: '如果您对隐私和资料安全有疑虑，欢迎 fork 我们的项目并自行架设服务。这样您可以完全控制自己的资料和 API 密钥。',
     paidPlanTitle: '付费方案需求',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -158,23 +158,23 @@ export default {
 
   // 隱私權頁面
   privacy: {
-    title: '隱私權政策 / Privacy Policy',
+    title: '隱私權政策',
     privacyPolicy: '隱私權政策',
     privacyDescription: '這款應用程式不會蒐集任何個人資料。生成的報告會暫時存儲於 R2 儲存服務中供您下載，並以唯一的 taskID 識別，其他使用者無法取得或存取您的資料。',
     privacyPolicyEn: 'Privacy Policy',
     privacyDescriptionEn: 'This application does not collect any private data whatsoever. Generated reports are temporarily stored in R2 storage service for your download and cannot be accessed by other users.',
-    dataProcessingTitle: '關於資料處理 / About Data Processing',
+    dataProcessingTitle: '關於資料處理',
     backendProcessing: '後端運算：資料會傳送到後端進行運算處理，但後端不會儲存任何使用者的個人資料和敏感資訊，特別是API KEY不會被儲存。',
     noCookies: '無cookies：我們不使用任何 cookies。',
     openSource: '開源透明：我們的程式碼完全開源，您可以檢視所有功能以確保隱私安全。',
-    frontendProject: '前端專案 (Frontend)',
-    backendProject: '後端專案 (Backend)',
+    frontendProject: '前端專案',
+    backendProject: '後端專案',
     openSourceNote: 'Open Source Transparency: Our code is completely open source, and you can review all functionality to ensure privacy. Check our frontend and backend repositories on GitHub.'
   },
 
   // 自行架站頁面
   selfHost: {
-    title: '🏗️ 自行架站指南 / Self-Hosting Guide',
+    title: '🏗️ 自行架站指南',
     overviewTitle: '📋 概述',
     overviewDescription: '如果您對隱私和資料安全有疑慮，歡迎 fork 我們的專案並自行架設服務。這樣您可以完全控制自己的資料和 API 金鑰。',
     paidPlanTitle: '付費方案需求',


### PR DESCRIPTION
在看隱私政策頁面時，發現有些標題有英文的輔助說明。目前已支持 i18n，應該可以拿掉英文輔助

![1764210548402](https://github.com/user-attachments/assets/3c7f8cef-ec75-4862-9b87-35403eea5cc3)

也可以解決在英文語系下，重複標題問題
![1764210551578](https://github.com/user-attachments/assets/2a7bef81-928b-4fbb-9261-e0a18ace5331)
