### PR TITLE
首頁加入 Uber 案例報告實例連結 (#57)

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -260,6 +260,7 @@ export default {
     title: 'Welcome to Sensemaker Opinion Integration Tool',
     description: 'Sensemaker Opinion Integration Tool is a powerful opinion survey report analysis tool that can help you extract valuable insights from large volumes of opinion survey reports.',
     sensemakingToolsLink: '2026 latest: Use OpenRouter or local LM Studio to generate a complete interactive HTML web report',
+    uberReportExample: 'Example report: "UberX Private Car Ride-hailing"',
     polisTitle: '1. Polis Opinion Survey Report Export',
     polisDescription: 'This tool supports opinion survey reports exported from the Polis platform. Please ensure your files conform to Polis data structure.',
     polisLink: 'View Guide →',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -247,6 +247,7 @@ export default {
     title: 'Bienvenido a la herramienta de integración de opiniones Sensemaker',
     description: 'La herramienta de integración de opiniones Sensemaker es una poderosa herramienta de análisis de informes de encuestas de opinión que puede ayudarle a extraer insights valiosos de grandes volúmenes de informes de encuestas de opinión.',
     sensemakingToolsLink: 'Version 2026: use OpenRouter o LM Studio local para generar un informe web HTML interactivo completo',
+    uberReportExample: 'Informe de ejemplo: «UberX, transporte de pasajeros en vehiculo privado»',
     polisTitle: '1. Exportación de informe de encuesta de opinión Polis',
     polisDescription: 'Esta herramienta soporta informes de encuestas de opinión exportados desde la plataforma Polis. Por favor asegúrese de que sus archivos cumplan con la estructura de datos de Polis.',
     polisLink: 'Ver guía →',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -247,6 +247,7 @@ export default {
     title: 'Bienvenue dans l\'outil d\'intégration d\'opinions Sensemaker',
     description: 'L\'outil d\'intégration d\'opinions Sensemaker est un outil puissant d\'analyse de rapports d\'enquêtes d\'opinion qui peut vous aider à extraire des insights précieux de grandes quantités de rapports d\'enquêtes d\'opinion.',
     sensemakingToolsLink: 'Version 2026: utilisez OpenRouter ou LM Studio en local pour generer un rapport web HTML interactif complet',
+    uberReportExample: 'Rapport exemple : « UberX, transport de passagers en voiture personnelle »',
     polisTitle: '1. Export de rapport d\'enquête d\'opinion Polis',
     polisDescription: 'Cet outil prend en charge les rapports d\'enquêtes d\'opinion exportés depuis la plateforme Polis. Veuillez vous assurer que vos fichiers sont conformes à la structure de données Polis.',
     polisLink: 'Voir le guide →',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -247,6 +247,7 @@ export default {
     title: 'Sensemaker意見統合ツールへようこそ',
     description: 'Sensemaker意見統合ツールは、大量の意見調査レポートから価値のある洞察を抽出するのに役立つ強力な意見調査レポート分析ツールです。',
     sensemakingToolsLink: '2026年最新版: OpenRouterまたはローカルのLM Studioで完全なインタラクティブHTMLウェブレポートを生成できます',
+    uberReportExample: 'レポート実例：「UberX 自家用車による旅客運送」',
     polisTitle: '1. Polis意見調査レポートのエクスポート',
     polisDescription: 'このツールは、Polisプラットフォームからエクスポートされた意見調査レポートをサポートしています。ファイルがPolisのデータ構造に準拠していることを確認してください。',
     polisLink: 'ガイドを表示 →',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -252,6 +252,7 @@ export default {
     title: '欢迎使用 Sensemaker意见综整器',
     description: 'Sensemaker 意见综整器是一个强大的意见调查报告分析工具，可以帮助您从大量意见调查报告中提取有价值的洞察。',
     sensemakingToolsLink: '2026最新版: 可用OpenRouter 或本地 LM Studio生成完整的互动式 HTML 网页报告',
+    uberReportExample: '报告实例：「UberX 自用车载客」',
     polisTitle: '1. Polis意见调查报告导出',
     polisDescription: '本工具支持 Polis 平台导出的意见调查报告。请确保您的文件符合 Polis 的数据结构。',
     polisLink: '查看说明 →',

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -265,6 +265,7 @@ export default {
     title: '歡迎使用 Sensemaker 意見綜整器',
     description: 'Sensemaker 意見綜整器是一個強大的意見調查報告分析工具，可以幫助您從大量意見調查報告中提取有價值的洞察。',
     sensemakingToolsLink: '2026最新版: 可用OpenRouter 或地端 LM Studio產生完整的互動式 HTML 網頁報告',
+    uberReportExample: '報告實例：「UberX 自用車載客」',
     polisTitle: '1. Polis意見調查報告導出',
     polisDescription: '本工具支援 Polis 平台導出的意見調查報告。請確保您的文件符合 Polis 的數據結構。',
     polisLink: '查看說明 →',

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -665,6 +665,15 @@ onUnmounted(() => {
           >
             {{ t('guideModal.sensemakingToolsLink') }}
           </a>
+          <br/>
+          <a
+            href="https://www.vtaiwan.tw/uber-x-report"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-blue-600 hover:text-blue-800 hover:underline"
+          >
+            {{ t('guideModal.uberReportExample') }}
+          </a>
         </p>
 
         <!-- 語言切換 -->


### PR DESCRIPTION
## 說明

Closes #57

在首頁說明區塊的「2026最新版: 可用OpenRouter 或地端 LM Studio產生完整的互動式 HTML 網頁報告」連結下方,新增一行報告實例連結。

- 文字(zh-TW):「報告實例：「UberX 自用車載客」」
- 連結:https://www.vtaiwan.tw/uber-x-report

## 變更

- `src/views/HomeView.vue`:新增 `<br/>` + 連結,沿用既有藍色連結樣式
- `src/i18n/locales/*.ts`:6 種語言(zh-TW / zh-CN / en / es / fr / ja)新增 `guideModal.uberReportExample`

## 驗證

- `vue-tsc --noEmit` 型別檢查通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)